### PR TITLE
fix: handle empty tier price during renewal

### DIFF
--- a/src/shop_bot/bot/handlers.py
+++ b/src/shop_bot/bot/handlers.py
@@ -31,6 +31,7 @@ from aiogram.enums import ChatMemberStatus
 from aiogram.exceptions import TelegramBadRequest
 from aiogram.utils.keyboard import InlineKeyboardBuilder
 from shop_bot.bot import keyboards
+from shop_bot.bot.pricing import tier_price_as_decimal
 from shop_bot.modules.platega_api import PlategaAPI
 from shop_bot.modules.heleket_api import create_heleket_payment_request
 from shop_bot.data_manager.remnawave_repository import (
@@ -2771,7 +2772,7 @@ def get_user_router() -> Router:
         months = int(plan.get('months') or 1)
         duration_days = int(plan.get('duration_days') or 0) or (months * 30)
         month_factor = Decimal(str(duration_days)) / Decimal('30')
-        price += Decimal(str(data.get('tier_price', 0))) * month_factor
+        price += tier_price_as_decimal(data.get('tier_price')) * month_factor
         await state.update_data(final_price=float(price))
         
         balance = get_balance(message.chat.id)

--- a/src/shop_bot/bot/pricing.py
+++ b/src/shop_bot/bot/pricing.py
@@ -1,0 +1,8 @@
+from decimal import Decimal
+
+
+def tier_price_as_decimal(value: object) -> Decimal:
+    """Convert an optional tier price without turning None into Decimal("None")."""
+    if value in (None, "", "None"):
+        return Decimal("0")
+    return Decimal(str(value))

--- a/tests/test_tier_price.py
+++ b/tests/test_tier_price.py
@@ -1,0 +1,19 @@
+import unittest
+from decimal import Decimal
+
+from shop_bot.bot.pricing import tier_price_as_decimal
+
+
+class TierPriceNormalizationTests(unittest.TestCase):
+    def test_empty_values_become_zero(self):
+        for value in (None, "", "None"):
+            with self.subTest(value=value):
+                self.assertEqual(tier_price_as_decimal(value), Decimal("0"))
+
+    def test_numeric_values_keep_their_amount(self):
+        self.assertEqual(tier_price_as_decimal("12.50"), Decimal("12.50"))
+        self.assertEqual(tier_price_as_decimal(7), Decimal("7"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Проблема

При продлении подписки `tier_price` может присутствовать в FSM-данных со значением `None` или пустой строкой. Текущий код вызывает `Decimal(str(tier_price))`, из-за чего возникает `decimal.InvalidOperation`, а пользователь не видит меню способов оплаты.

## Решение

- нормализовать `None`, пустую строку и строку `"None"` в `Decimal("0")`;
- оставить обычные числовые значения без изменения;
- использовать отдельную небольшую функцию, которую можно проверить независимо.

## Проверка

```text
python -m unittest discover -s tests -p 'test_tier_price.py' -v
Ran 2 tests — OK
```

Также выполнены `py_compile`, `git diff --check` и `pip check`.

## Область изменений

Только:

- `src/shop_bot/bot/handlers.py`;
- `src/shop_bot/bot/pricing.py`;
- `tests/test_tier_price.py`.

Production-конфигурация и данные не затрагиваются.
